### PR TITLE
Removed the bug in the categories section

### DIFF
--- a/resource.html
+++ b/resource.html
@@ -115,9 +115,6 @@
           </div>
         </li>
         <li class="category">
-
-          <button class="link-dark btn-style shadow-none">Designing</button>
-
           <button class="link-dark btn-style">Application Programming Interface</button>
           <div class="select-option">
             <button class="btn select-category-btn" value="api">


### PR DESCRIPTION
## 🛠️ Fixes Issue
- _Describe the issue fixed here_
- This is a pull request regarding the issue #284
There was an extra designing tab in the categories section which on clicking opened the subfolders of the API tab. I removed that designing tab.
- Contributing under GSSoC '22
-----------------------------------------------------------

### 👨‍💻 Changes Proposed
-----------------------------------------------------------

### :heavy_check_mark: Check List ( Check all the applicable boxes )
- [x] My code follows the code style of this project.
- [x] This PR does not contain Plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
-----------------------------------------------------------

### :memo:  Note to reviewers
- @rucha0702 
-----------------------------------------------------------

### 📷 Screenshots
The bug:
<img width="275" alt="designingerror" src="https://user-images.githubusercontent.com/99873488/166521111-770b3000-9c29-4a96-9241-0d6f4f11c082.png">

After removing it:
<img width="290" alt="removedthebug" src="https://user-images.githubusercontent.com/99873488/166521197-f741e07b-4b8e-451e-aa1e-51a2a55406e9.png">

-----------------------------------------------------------

